### PR TITLE
Search on assets pages

### DIFF
--- a/app/assets/scripts/actions/action-creators.js
+++ b/app/assets/scripts/actions/action-creators.js
@@ -140,6 +140,20 @@ export function fetchFieldVProMMsIds (json) {
   };
 }
 
+export function fetchAllVProMMsIds (json) {
+  return function (dispatch) {
+    dispatch(requestFieldVProMMsids());
+    const url = `${config.api}/field/ids/all`;
+    return fetch(url)
+      .then(response => response.json())
+      .then(json => {
+        if (json.statusCode >= 400) {
+          throw new Error('Bad Response');
+        }
+        dispatch(receiveFieldVProMMsids(json));
+      });
+  };
+}
 
 // ////////////////////////////////////////////////////////////////
 //                             Search                            //

--- a/app/assets/scripts/components/assets-search.js
+++ b/app/assets/scripts/components/assets-search.js
@@ -1,6 +1,5 @@
 'use strict';
 import React from 'react';
-import _ from 'lodash';
 import {
   compose,
   getContext

--- a/app/assets/scripts/components/assets-search.js
+++ b/app/assets/scripts/components/assets-search.js
@@ -9,7 +9,7 @@ import { connect } from 'react-redux';
 
 import {
   setSearchType,
-  fetchFieldVProMMsIds,
+  fetchAllVProMMsIds,
   setFilteredVProMMs,
   fetchAdmins,
   clearAdmins,
@@ -42,7 +42,7 @@ export default compose(
       fetching: state.admins.fetching
     }),
     (dispatch, { location }) => ({
-      _fetchFieldVProMMsIds: (...args) => dispatch(fetchFieldVProMMsIds(...args)),
+      _fetchFieldVProMMsIds: (...args) => dispatch(fetchAllVProMMsIds(...args)),
       _setSearchType: (...args) => dispatch(setSearchType(...args)),
       _setFilteredVProMMs: (filteredVProMMs) => dispatch(setFilteredVProMMs(filteredVProMMs)),
       _clearAdmins: () => dispatch(clearAdmins()),

--- a/app/assets/scripts/components/base-search.js
+++ b/app/assets/scripts/components/base-search.js
@@ -1,0 +1,255 @@
+'use strict';
+
+import React from 'react';
+import _ from 'lodash';
+import T, {
+  translate
+} from './t';
+
+
+
+var BaseSearch = React.createClass({
+  displayName: 'MapSearch',
+
+  propTypes: {
+    searchType: React.PropTypes.string,
+    fetching: React.PropTypes.bool,
+    vpromms: React.PropTypes.array,
+    admins: React.PropTypes.array,
+    filteredVProMMs: React.PropTypes.array,
+    language: React.PropTypes.string,
+    _setSearchType: React.PropTypes.func,
+    _fetchAdmins: React.PropTypes.func,
+    _clearAdmins: React.PropTypes.func,
+    _setFilteredVProMMs: React.PropTypes.func,
+    fetchRoadBbox: React.PropTypes.func,
+    _fetchFieldVProMMsIds: React.PropTypes.func,
+    _fetchAdminBbox: React.PropTypes.func,
+    fetchRoadProperty: React.PropTypes.func
+  },
+
+  getInitialState: function () {
+    return {
+      searchVal: '',
+      showResults: true
+    };
+  },
+
+  componentDidMount: function () {
+    this.props._fetchFieldVProMMsIds();
+    this.search = _.debounce(this.search, 300);
+  },
+
+  componentWillUnmount: function () {
+    this.props._clearAdmins();
+    this.props._setFilteredVProMMs([]);
+  },
+
+  componentWillReceiveProps: function (nextProps) {
+    if (this.props.language !== nextProps.language) {
+      this.setState({ searchVal: '', showResults: false });
+      this.props._clearAdmins();
+      this.props._setFilteredVProMMs([]);
+    }
+  },
+
+  onClearSearch: function (e) {
+    this.setState({ searchVal: '', showResults: false });
+    this.props._clearAdmins();
+    this.props._setFilteredVProMMs([]);
+  },
+
+  onSearchTypeChange: function (e) {
+    this.props._setSearchType(e.target.value);
+    this.setState({ searchVal: '', showResults: true });
+    this.props._clearAdmins();
+    this.props._setFilteredVProMMs([]);
+  },
+
+  onSearchQueryChange: function (e) {
+    var searchVal = e.target.value;
+    this.setState({ searchVal, showResults: true });
+    // The search function is debounced.
+    this.search(_.trim(searchVal));
+  },
+
+  onSearchSubmit: function (e) {
+    e.preventDefault();
+    this.setState({ showResults: true });
+    // On enter, use the first value. Feeling lucky!
+    var searchVal = this.state.searchVal;
+    if (searchVal.length) {
+      if (this.props.searchType === 'Admin' && this.props.admins[0]) {
+        this.searchAdminArea(this.props.admins[0].id);
+        this.setState({ searchVal: this.props.admins[0].name_en });
+      } else if (this.props.filteredVProMMs[0]) {
+        this.searchVProMMsID(this.props.filteredVProMMs[0]);
+        this.setState({ searchVal: this.props.filteredVProMMs[0] });
+      }
+    }
+  },
+
+  search: function (searchVal) {
+    if (this.props.searchType === 'Admin') {
+      if (searchVal.length > 0) {
+        this.props._fetchAdmins(searchVal);
+      } else {
+        this.props._clearAdmins();
+      }
+    } else {
+      if (searchVal.length >= 2) {
+        // Filter the available vpromms.
+        const matches = this.props.vpromms.filter((vpromm) => {
+          return vpromm.slice(0, searchVal.length) === searchVal.toUpperCase();
+        });
+        this.props._setFilteredVProMMs(matches.slice(0, 10));
+      } else {
+        this.props._setFilteredVProMMs([]);
+      }
+    }
+  },
+
+  searchVProMMsID: function (VProMMsID) {
+    this.setState({ showResults: false }, () => {
+      // Wait for the state to be set, otherwise the shouldComponentUpdate
+      // of the parent will prevent the re-render.
+      // This is an artifact.
+      this.props.fetchRoadBbox(VProMMsID);
+      this.props.fetchRoadProperty(VProMMsID);
+    });
+  },
+
+  searchAdminArea: function (adminAreaID) {
+    this.setState({ showResults: false }, () => {
+      // Wait for the state to be set, otherwise the shouldComponentUpdate
+      // of the parent will prevent the re-render.
+      // This is an artifact.
+      this.props._fetchAdminBbox(adminAreaID);
+    });
+  },
+
+  onAAClick: function (aa, e) {
+    e.preventDefault();
+    this.searchAdminArea(aa.id);
+    this.setState({ searchVal: this.props.language === 'en' ? aa.name_en : aa.name_vn });
+  },
+
+  onVprommClick: function (id, e) {
+    e.preventDefault();
+    this.searchVProMMsID(id);
+    this.setState({ searchVal: id });
+  },
+
+  renderResults: function () {
+    if (!this.state.showResults) {
+      return null;
+    }
+
+    if (this.props.fetching) {
+      return (
+        <div className='search-results'>
+          <p className='info'><T>Loading</T>...</p>
+        </div>
+      );
+    }
+
+    // Data to work with depends n the search type.
+    let data = this.props.searchType === 'Admin' ? this.props.admins : this.props.filteredVProMMs;
+    let contents = null;
+
+    if (this.props.searchType === 'Admin') {
+      if (data.length) {
+        contents = _(data)
+          .groupBy(o => o.level)
+          .reduce((acc, level, key) => {
+            acc.push(<h4 key={`aa-type-admin-${key}`}><T>Admin Level</T> - <T>{key}</T></h4>);
+
+            let adminAreas = level.reduce((_acc, o) => {
+              return _acc.concat(<li key={o.id}><a href='#' onClick={this.onAAClick.bind(null, o)}>{this.props.language === 'en' ? o.name_en : o.name_vn}</a></li>);
+            }, []);
+
+            acc.push(<ul key={`aa-admins-${key}`}>{adminAreas}</ul>);
+
+            return acc;
+          }, []);
+      } else {
+        if (this.state.searchVal) {
+          contents = <p className='info' key='no-results'><T>No results available. Please refine your search</T></p>;
+        }
+      }
+    } else if (this.props.searchType === 'VProMMs' && this.state.searchVal.length >= 2) {
+      if (!data.length) {
+        contents = <p className='info' key='no-results'><T>No results available. Please refine your search</T></p>;
+      } else {
+        contents = [<h4 key={`vpromms-title`}>VProMMs</h4>];
+
+        let vpromms = data.reduce((acc, o, key) => {
+          return acc.concat(<li key={o}><a href='#' onClick={this.onVprommClick.bind(null, o)}>{o}</a></li>);
+        }, []);
+
+        contents.push(<ul key={`vpromms-list`}>{vpromms}</ul>);
+      }
+    }
+
+    if (contents === null) {
+      return null;
+    }
+
+    return (
+      <div className='search-results'>
+        <div className='inner'>
+          {contents}
+        </div>
+      </div>
+    );
+  },
+
+  render: function () {
+    const { language, searchType } = this.props;
+
+    return (
+      <form className='form search' onSubmit={this.onSearchSubmit}>
+        <div className='form__group'>
+          <label className='form__label' htmlFor='search-field'><T>Search</T></label>
+          <div className='form__input-group form__input-group--medium'>
+            <select className='form__control' onChange={this.onSearchTypeChange} value={searchType}>
+              <option value='Admin'>{translate(language, 'Admin')}</option>
+              <option value='VProMMs'>VProMMs</option>
+            </select>
+            <input
+              type='text'
+              id='search-field'
+              name='search-field'
+              className='form__control'
+              placeholder={translate(language, 'Search')}
+              value={this.state.searchVal}
+              onChange={this.onSearchQueryChange} />
+            <button
+              type='button'
+              className='search__button'
+              onClick={this.onSearchSubmit}
+            >
+              <span><T>Search</T></span>
+            </button>
+          </div>
+
+          {this.state.searchVal !== '' &&
+            <button
+              type='button'
+              className='search__clear'
+              title={translate(language, 'Clear search')}
+              onClick={this.onClearSearch}
+            >
+              <span><T>Clear search</T></span>
+            </button>
+          }
+
+          {this.renderResults()}
+
+        </div>
+      </form>
+    );
+  }
+});
+
+export default BaseSearch;

--- a/app/assets/scripts/components/base-search.js
+++ b/app/assets/scripts/components/base-search.js
@@ -79,7 +79,6 @@ var BaseSearch = React.createClass({
     e.preventDefault();
     this.setState({ showResults: true });
     const { page } = this.props;
-    console.log('submitAction', submitAction);
     // On enter, use the first value. Feeling lucky!
     var searchVal = this.state.searchVal;
     if (searchVal.length) {
@@ -95,7 +94,7 @@ var BaseSearch = React.createClass({
     }
   },
 
-  navigateToAdmin: function(admin) {
+  navigateToAdmin: function (admin) {
     if (admin.level === 'province') {
       const url = `${this.props.language}/assets/${admin.id}`;
       this.props.router.push(url);
@@ -111,7 +110,7 @@ var BaseSearch = React.createClass({
     }
   },
 
-  navigateToVProMM: function(vpromm) {
+  navigateToVProMM: function (vpromm) {
     const url = `${this.props.language}/assets/road/${vpromm}`;
     this.props.router.push(url);
   },
@@ -172,11 +171,9 @@ var BaseSearch = React.createClass({
   },
 
   renderResults: function () {
-
     if (!this.state.showResults) {
       return null;
     }
-
     if (this.props.fetching) {
       return (
         <div className='search-results'>
@@ -190,24 +187,19 @@ var BaseSearch = React.createClass({
     let contents = null;
 
     if (this.props.searchType === 'Admin') {
-      
       // on the assets page, we don't want to show communes in the admin results
       if (this.props.page === 'assets') {
         data = data.filter(o => o.level !== 'commune');
       }
       if (data.length) {
-
         contents = _(data)
           .groupBy(o => o.level)
           .reduce((acc, level, key) => {
             acc.push(<h4 key={`aa-type-admin-${key}`}><T>Admin Level</T> - <T>{key}</T></h4>);
-
             let adminAreas = level.reduce((_acc, o) => {
               return _acc.concat(<li key={o.id}><a href='#' onClick={this.onAAClick.bind(null, o)}>{this.props.language === 'en' ? o.name_en : o.name_vn}</a></li>);
             }, []);
-
             acc.push(<ul key={`aa-admins-${key}`}>{adminAreas}</ul>);
-
             return acc;
           }, []);
       } else {

--- a/app/assets/scripts/components/base-search.js
+++ b/app/assets/scripts/components/base-search.js
@@ -84,11 +84,11 @@ var BaseSearch = React.createClass({
     if (searchVal.length) {
       if (this.props.searchType === 'Admin' && this.props.admins[0]) {
         const admin = this.props.admins[0];
-        page === 'explore' ? this.searchAdminArea(admin.id) : this.navigateToAdmin(admin);
+        page === 'assets' ? this.navigateToAdmin(admin) : this.searchAdminArea(admin.id);
         this.setState({ searchVal: this.props.admins[0].name_en });
       } else if (this.props.filteredVProMMs[0]) {
         const vpromm = this.props.filteredVProMMs[0];
-        page === 'explore' ? this.searchVProMMsID(vpromm) : this.navigateToVProMM(vpromm);
+        page === 'assets' ? this.navigateToVProMM(vpromm) : this.searchVProMMsID(vpromm);
         this.setState({ searchVal: this.props.filteredVProMMs[0] });
       }
     }
@@ -158,7 +158,7 @@ var BaseSearch = React.createClass({
     // console.log('onAAClick called');
     const { page } = this.props;
     e.preventDefault();
-    page === 'explore' ? this.searchAdminArea(aa.id) : this.navigateToAdmin(aa);
+    page === 'assets' ? this.navigateToAdmin(aa) : this.searchAdminArea(aa.id);
     this.setState({ searchVal: this.props.language === 'en' ? aa.name_en : aa.name_vn });
   },
 
@@ -166,7 +166,7 @@ var BaseSearch = React.createClass({
     // console.log('onVprommClick called');
     const { page } = this.props;
     e.preventDefault();
-    page === 'explore' ? this.searchVProMMsID(id) : this.navigateToVProMM(id);
+    page === 'assets' ? this.navigateToVProMM(id) : this.searchVProMMsID(id);
     this.setState({ searchVal: id });
   },
 

--- a/app/assets/scripts/components/map-search.js
+++ b/app/assets/scripts/components/map-search.js
@@ -1,6 +1,5 @@
 'use strict';
 import React from 'react';
-import _ from 'lodash';
 import {
   compose,
   getContext

--- a/app/assets/scripts/views/assets.js
+++ b/app/assets/scripts/views/assets.js
@@ -11,7 +11,7 @@ const Assets = ({ children }) => (
           <h1 className='inpage__title'><T>Assets</T></h1>
         </div>
         <div className='inpage__actions'>
-          <AssetsSearch />
+          <AssetsSearch page='assets' />
         </div>
       </div>
     </header>

--- a/app/assets/scripts/views/assets.js
+++ b/app/assets/scripts/views/assets.js
@@ -1,6 +1,7 @@
 'use strict';
 import React from 'react';
 import T from '../components/t';
+import AssetsSearch from '../components/assets-search';
 
 const Assets = ({ children }) => (
   <section className='inpage'>
@@ -8,6 +9,9 @@ const Assets = ({ children }) => (
       <div className='inner'>
         <div className='inpage__headline'>
           <h1 className='inpage__title'><T>Assets</T></h1>
+        </div>
+        <div className='inpage__actions'>
+          <AssetsSearch />
         </div>
       </div>
     </header>

--- a/app/assets/scripts/views/editor.js
+++ b/app/assets/scripts/views/editor.js
@@ -92,7 +92,7 @@ var Editor = React.createClass({
               <h1 className='inpage__title'><T>Editor</T></h1>
             </div>
             <div className='inpage__actions'>
-              <MapSearch />
+              <MapSearch page="editor" />
             </div>
           </div>
         </header>

--- a/app/assets/scripts/views/explore.js
+++ b/app/assets/scripts/views/explore.js
@@ -258,7 +258,7 @@ var Explore = React.createClass({
               <h1 className='inpage__title'><T>Explore</T></h1>
             </div>
             <div className='inpage__actions'>
-              <MapSearch />
+              <MapSearch page='explore' />
             </div>
           </div>
         </header>


### PR DESCRIPTION
NOTE: This is branched from `feature/assets-list` so we should merge that first.

This implements a similar search box for Admins and VProMMs as the `Explore` page on the `Assets` pages, allowing a user to quickly search for an admin area or VProMM id and quickly jump to that detail page.

There's a couple of small things I'd like to fix before merging, but it should all basically work as is.

Things to fix:

 - Make sure search drop-down collapses after user clicks
 - Do we need some loading when navigating to Districts (since it needs to make an additional API call?)

@danielfdsilva thanks much for your help refactoring this search component. The one thing we landed up having to do here was make an additional API call to fetch the parent id for a selected  district to construct the URL to navigate to. The simplest way seemed to be to just do the `fetch` call in the component like so: https://github.com/orma/openroads-vn-analytics/commit/e03535fcb5741c04a15b7060cbd497eb72be7372#diff-bece897262cca0ba2ae256d0844a1660R104 - if this doesn't seem right, please let me know what might be a better way to do this :) - and, of course, any other comments on the code very welcome.

cc @geohacker 