### PR TITLE
show province status counts as returned from api

### DIFF
--- a/app/assets/scripts/redux/modules/road-count.js
+++ b/app/assets/scripts/redux/modules/road-count.js
@@ -11,6 +11,16 @@ import config from '../../config';
 export const getRoadCountKey = (province, district) =>
   district ? `${province}-${district}` : province;
 
+/**
+ * This function is used primarily to merge in the `totalRoads` and `osmRoads`
+ * properties from the counts request with an admin-area object.
+ *
+ * @param {Object} aa - admin area object to be augmented with counts
+ * @param {Object} data - data object that holds the counts
+ * @param {String} path - path to property in data object that holds counts
+ * @param {Object} additional - additional key-values to be added to the `aa` object
+ * @returns {Object} admin-area object, augmented as above
+ */
 export const mergeAA = (aa, data, path, additional = {}) => {
   if (!aa.code) return aa;
   const count = _.get(data, path, {});

--- a/app/assets/scripts/views/assets-index.js
+++ b/app/assets/scripts/views/assets-index.js
@@ -230,11 +230,7 @@ export default compose(
             data: {
               provinces: state.adminStats.index.data.provinces.map(prov => {
                 const districts = prov.districts.map(district => mergeAA(district, countData, [prov.code, 'district', district.code]));
-                const status = {
-                  pending: districts.reduce((acc, d) => acc + _.get(d, 'status.pending', 0), 0),
-                  reviewed: districts.reduce((acc, d) => acc + _.get(d, 'status.reviewed', 0), 0)
-                };
-                return mergeAA(prov, countData, [prov.code], {districts, status});
+                return mergeAA(prov, countData, [prov.code], {districts});
               })
             }
           }


### PR DESCRIPTION
Removes code that was summing up district counts for status.

cc @geohacker 