### PR TITLE
Get both provinces and districts in tasks search, handle search for districts

### DIFF
--- a/app/assets/scripts/actions/action-creators.js
+++ b/app/assets/scripts/actions/action-creators.js
@@ -223,14 +223,25 @@ function receiveProvinces (json) {
 export function fetchProvinces () {
   return function (dispatch) {
     dispatch(requestProvinces());
-    let url = `${config.api}/admin/province/units`;
-    return fetch(url)
+    let provinceUrl = `${config.api}/admin/province/units`;
+    let districtUrl = `${config.api}/admin/district/units`;
+    return fetch(provinceUrl)
       .then(response => response.json())
-      .then(json => {
-        if (json.statusCode >= 400) {
+      .then(provinces => {
+        if (provinces.statusCode >= 400) {
           throw new Error('Bad response');
         }
-        dispatch(receiveProvinces(json));
+        return fetch(districtUrl)
+          .then(response => response.json())
+          .then(districts => {
+            if (districts.statusCode >= 400) {
+              throw new Error('Bad response');
+            }
+            dispatch(receiveProvinces({
+              provinces,
+              districts
+            }))
+          })
       });
   };
 }

--- a/app/assets/scripts/actions/action-creators.js
+++ b/app/assets/scripts/actions/action-creators.js
@@ -240,8 +240,8 @@ export function fetchProvinces () {
             dispatch(receiveProvinces({
               provinces,
               districts
-            }))
-          })
+            }));
+          });
       });
   };
 }

--- a/app/assets/scripts/redux/modules/tasks.js
+++ b/app/assets/scripts/redux/modules/tasks.js
@@ -122,8 +122,14 @@ export const fetchWayTaskEpic = taskId => (dispatch, getState) => {
 
 export const fetchWayTaskCountEpic = () => (dispatch, getState) => {
   dispatch(fetchWayTaskCount());
-  const selectedProvince = getState().waytasks.selectedProvince;
-  const url = selectedProvince ? `${config.api}/tasks/count?province=${selectedProvince}` : `${config.api}/tasks/count`;
+  const selectedBoundary = getState().waytasks.selectedProvince;
+  let allBoundaries, boundaryType;
+  if (selectedBoundary) {
+    allBoundaries = getState().provinces.data;
+    boundaryType = getBoundaryType(allBoundaries, selectedBoundary);
+  }
+
+  const url = selectedBoundary ? `${config.api}/tasks/count?${boundaryType}=${selectedBoundary}` : `${config.api}/tasks/count`;
 
   fetch(url)
     .then(response => {

--- a/app/assets/scripts/redux/modules/tasks.js
+++ b/app/assets/scripts/redux/modules/tasks.js
@@ -44,7 +44,7 @@ export const dedupeWayTask = (taskId, wayIds, wayIdToKeep, dedupeId) => ({ type:
 export const dedupeWayTaskSuccess = () => ({ type: DEDUPE_WAY_TASK_SUCCESS });
 export const dedupeWayTaskError = (error) => ({ type: DEDUPE_WAY_TASK_ERROR, error: error });
 
-function getBoundaryType(allAdmins, selected) {
+function getBoundaryType (allAdmins, selected) {
   const districtIds = allAdmins.districts.district.map(d => d.id);
   const provinceIds = allAdmins.provinces.province.map(p => p.id);
   if (districtIds.indexOf(selected) !== -1) {

--- a/app/assets/scripts/views/tasks.js
+++ b/app/assets/scripts/views/tasks.js
@@ -786,7 +786,7 @@ var Tasks = React.createClass({
     const { selectedProvince, language } = this.props;
 
     const provinceOptions = this.props.selectOptions.provinces.province.map((p) => { return {value: p.id, label: `${p.name_en} (P)`}; });
-    const districtOptions = this.props.selectOptions.districts.district.map((d) => { return { value: d.id, label: `${d.name_en} (D)`}; });
+    const districtOptions = this.props.selectOptions.districts.district.map((d) => { return {value: d.id, label: `${d.name_en} (D)`}; });
     const options = [].concat(provinceOptions).concat(districtOptions);
     const value = selectedProvince;
     return (

--- a/app/assets/scripts/views/tasks.js
+++ b/app/assets/scripts/views/tasks.js
@@ -795,7 +795,7 @@ var Tasks = React.createClass({
         value={value}
         onChange= {this.handleProvinceChange}
         options={ options }
-        placeholder ={ translate(language, 'Filter tasks by province') }
+        placeholder ={ translate(language, 'Filter by province or district') }
       />
     );
   },

--- a/app/assets/scripts/views/tasks.js
+++ b/app/assets/scripts/views/tasks.js
@@ -784,14 +784,17 @@ var Tasks = React.createClass({
 
   renderProvinceSelect: function () {
     const { selectedProvince, language } = this.props;
-    const provinceOptions = this.props.selectOptions.province.map((p) => { return {value: p.id, label: p.name_en}; });
+
+    const provinceOptions = this.props.selectOptions.provinces.province.map((p) => { return {value: p.id, label: `${p.name_en} (P)`}; });
+    const districtOptions = this.props.selectOptions.districts.district.map((d) => { return { value: d.id, label: `${d.name_en} (D)`}; });
+    const options = [].concat(provinceOptions).concat(districtOptions);
     const value = selectedProvince;
     return (
       <Select
         name="form-province-select"
         value={value}
         onChange= {this.handleProvinceChange}
-        options={ provinceOptions }
+        options={ options }
         placeholder ={ translate(language, 'Filter tasks by province') }
       />
     );
@@ -802,7 +805,7 @@ var Tasks = React.createClass({
     const { hoverId } = this.state;
     const renderPanel = !((taskStatus === 'error' || taskStatus === 'No tasks remaining') ||
                               (!taskId && taskStatus === 'pending'));
-
+    // console.log('selectOptions', this.props.selectOptions);
     return (
       <section className='inpage inpage--alt'>
         <header className='inpage__header'>
@@ -819,7 +822,7 @@ var Tasks = React.createClass({
             <div className='inpage__actions'>
               <div className='form__group task-search'>
                 <label className='form__label' htmlFor='form-select-1'><T>Search admin area</T></label>
-                { this.props.selectOptions.province && this.renderProvinceSelect() }
+                { this.props.selectOptions.provinces && this.renderProvinceSelect() }
               </div>
             </div>
           </div>


### PR DESCRIPTION
@geohacker - this code should  work to add districts to the search box and allow searching by districts.

If we can find a good flow to test that it all works with real data, I can make some cosmetic changes to variable names, etc. to make this code read a little bit better (I have not yet renamed all the variables which say "province" when they should now say something like "boundary" since it could be either a province or a district).