### PR TITLE
[wip] work for new tileset with cvts and iri as properties in single tileset

### DIFF
--- a/app/assets/scripts/components/map-legend.js
+++ b/app/assets/scripts/components/map-legend.js
@@ -7,7 +7,7 @@ import T from './t';
 
 
 const renderTitle = (layer) => {
-  if (layer === 'iri') {
+  if (layer === 'iri_mean') {
     return <T>IRI</T>;
   } else if (layer === 'or_width') {
     return <T>Width</T>;
@@ -21,6 +21,7 @@ const renderTitle = (layer) => {
 };
 
 const MapLegend = ({ layer }) => {
+  console.log('LAYER', layer);
   const colors = lineColors[layer];
   const continuous = (colors.type !== 'categorical');
   const stops = colors.stops;

--- a/app/assets/scripts/components/map-legend.js
+++ b/app/assets/scripts/components/map-legend.js
@@ -15,7 +15,7 @@ const renderTitle = (layer) => {
     return <T>Condition</T>;
   } else if (layer === 'or_surface') {
     return <T>Surface</T>;
-  } else if (layer === 'cvts') {
+  } else if (layer === 'or_section_delivery_vehicle') {
     return <T>Vehicle Count</T>;
   }
 };

--- a/app/assets/scripts/components/map-options.js
+++ b/app/assets/scripts/components/map-options.js
@@ -15,7 +15,7 @@ const MapOptions = ({ layer, language, handleLayerChange, handleShowNoVpromms })
           <label className='form__label'><T>Visualized variable</T></label>
           <select className='form__control' onChange={ e => handleLayerChange(e) }>
             <option value='iri'>{translate(language, 'IRI')}</option>
-            <option value='cvts'>{translate(language, 'CVTS')}</option>
+            <option value='or_section_delivery_vehicle'>{translate(language, 'CVTS')}</option>
           </select>
         </div>
         {layer === 'iri' && (

--- a/app/assets/scripts/components/map-options.js
+++ b/app/assets/scripts/components/map-options.js
@@ -14,11 +14,11 @@ const MapOptions = ({ layer, language, handleLayerChange, handleShowNoVpromms })
         <div className='form__group'>
           <label className='form__label'><T>Visualized variable</T></label>
           <select className='form__control' onChange={ e => handleLayerChange(e) }>
-            <option value='iri'>{translate(language, 'IRI')}</option>
+            <option value='iri_mean'>{translate(language, 'IRI')}</option>
             <option value='or_section_delivery_vehicle'>{translate(language, 'CVTS')}</option>
           </select>
         </div>
-        {layer === 'iri' && (
+        {layer === 'iri_mean' && (
           <div className='form__group'>
             <label className='form__label'>{translate(language, 'Options')}</label>
             <label

--- a/app/assets/scripts/redux/reducer.js
+++ b/app/assets/scripts/redux/reducer.js
@@ -89,7 +89,7 @@ const fieldVProMMsids = function (state = defaultFieldVProMMsids, action) {
 };
 
 const exploreMapDefaultState = {
-  layer: 'iri',
+  layer: 'iri_mean',
   showNoVpromms: true
 };
 const exploreMap = function (state = exploreMapDefaultState, action) {

--- a/app/assets/scripts/utils/line-colors.js
+++ b/app/assets/scripts/utils/line-colors.js
@@ -13,13 +13,14 @@ module.exports = {
   // property and colors for CVTS visualization
   'or_section_delivery_vehicle': {
     property: 'or_section_delivery_vehicle',
-    default: 0,
+    // default: 0,
     type: 'exponential',
-    colorSpace: 'lab',
+    colorSpace: 'hcl',
     stops: [
-      [3, '#8CCA1B'],
-      [16, '#DA251D'],
-      [30, '#8f1813']
+      [1, '#8CCA1B'],
+      [50, '#e85953'],
+      [300, '#DA251D'],
+      [1000, '#8f1813']
     ]
   },
   'RouteShoot': {

--- a/app/assets/scripts/utils/line-colors.js
+++ b/app/assets/scripts/utils/line-colors.js
@@ -1,6 +1,6 @@
 module.exports = {
-  'iri': {
-    property: 'iri',
+  'iri_mean': {
+    property: 'iri_mean',
     type: 'exponential',
     colorSpace: 'lab',
     stops: [
@@ -13,6 +13,7 @@ module.exports = {
   // property and colors for CVTS visualization
   'or_section_delivery_vehicle': {
     property: 'or_section_delivery_vehicle',
+    default: 0,
     type: 'exponential',
     colorSpace: 'lab',
     stops: [

--- a/app/assets/scripts/utils/line-colors.js
+++ b/app/assets/scripts/utils/line-colors.js
@@ -9,7 +9,9 @@ module.exports = {
       [30, '#8f1813']
     ]
   },
-  'cvts': {
+
+  // property and colors for CVTS visualization
+  'or_section_delivery_vehicle': {
     property: 'or_section_delivery_vehicle',
     type: 'exponential',
     colorSpace: 'lab',

--- a/app/assets/scripts/views/explore.js
+++ b/app/assets/scripts/views/explore.js
@@ -202,21 +202,28 @@ var Explore = React.createClass({
         .setPaintProperty(
           'novpromm',
           'line-color',
-          lineColors['iri']
+          lineColors['iri_mean']
         )
         .setPaintProperty(
           'novpromm_dashed',
           'line-color',
-          lineColors['iri']
+          lineColors['iri_mean']
         )
         .setPaintProperty(
           'vpromm',
           'line-color',
-          lineColors['iri']
+          lineColors['iri_mean']
         );
 
       this.map.on('mousemove', (e) => {
+        // console.log('moved on map');
         const features = this.map.queryRenderedFeatures(e.point, {layers: ['vpromm-interaction']});
+        features.forEach(f => {
+          console.log(f);
+          if (f.properties.or_section_delivery_vehicle) {
+            console.log('prop', f.properties.or_section_delivery_vehicle);
+          }
+        });
         this.map.getCanvas().style.cursor = features.length ? 'pointer' : '';
       });
 
@@ -269,7 +276,7 @@ var Explore = React.createClass({
   handleLayerChange: function ({ target: { value } }) {
     this.props.selectExploreMapLayer(value);
     this.map.setPaintProperty(
-      'conflated',
+      'vpromm',
       'line-color',
       lineColors[value]
     );

--- a/app/assets/scripts/views/explore.js
+++ b/app/assets/scripts/views/explore.js
@@ -199,22 +199,6 @@ var Explore = React.createClass({
           layout: {'line-cap': 'round'},
           filter: ['has', 'or_vpromms']
         })
-        .addLayer({
-          id: 'cvts',
-          type: 'line',
-          source: {
-            type: 'vector',
-            url: 'mapbox://openroads.18lep9y5'
-          },
-          'source-layer': 'license-counts-cv07we',
-          paint: {
-            'line-width': 1,
-            'line-opacity': 1
-          },
-          layout: {
-            visibility: 'none'
-          }
-        })
         .setPaintProperty(
           'novpromm',
           'line-color',
@@ -232,7 +216,7 @@ var Explore = React.createClass({
         );
 
       this.map.on('mousemove', (e) => {
-        const features = this.map.queryRenderedFeatures(e.point, {layers: ['vpromm-interaction', 'cvts']});
+        const features = this.map.queryRenderedFeatures(e.point, {layers: ['vpromm-interaction']});
         this.map.getCanvas().style.cursor = features.length ? 'pointer' : '';
       });
 
@@ -246,21 +230,21 @@ var Explore = React.createClass({
   },
 
   switchLayerTo: function (layer) {
-    if (layer === 'cvts') {
-      this.map.setLayoutProperty('vpromm', 'visibility', 'none');
-      this.map.setLayoutProperty('novpromm', 'visibility', 'none');
-      this.map.setLayoutProperty('novpromm_dashed', 'visibility', 'none');
-      this.map.setLayoutProperty('vpromm-interaction', 'visibility', 'none');
-      this.map.setLayoutProperty('cvts', 'visibility', 'visible');
-      this.map.setPaintProperty('cvts', 'line-color', lineColors['cvts']);
-      this.map.setZoom(9);
-    } else if (layer === 'iri') {
-      this.map.setLayoutProperty('vpromm', 'visibility', 'visible');
-      this.map.setLayoutProperty('novpromm', 'visibility', 'visible');
-      this.map.setLayoutProperty('novpromm_dashed', 'visibility', 'visible');
-      this.map.setLayoutProperty('vpromm-interaction', 'visibility', 'visible');
-      this.map.setLayoutProperty('cvts', 'visibility', 'none');
-    }
+    this.map.setPaintProperty(
+      'novpromm',
+      'line-color',
+      lineColors[layer]
+    )
+    .setPaintProperty(
+      'novpromm_dashed',
+      'line-color',
+      lineColors[layer]
+    )
+    .setPaintProperty(
+      'vpromm',
+      'line-color',
+      lineColors[layer]
+    );
   },
 
   componentWillReceiveProps: function ({ layer, lng, lat, zoom, activeRoad }) {

--- a/app/assets/scripts/views/explore.js
+++ b/app/assets/scripts/views/explore.js
@@ -235,16 +235,16 @@ var Explore = React.createClass({
       'line-color',
       lineColors[layer]
     )
-    .setPaintProperty(
-      'novpromm_dashed',
-      'line-color',
-      lineColors[layer]
-    )
-    .setPaintProperty(
-      'vpromm',
-      'line-color',
-      lineColors[layer]
-    );
+      .setPaintProperty(
+        'novpromm_dashed',
+        'line-color',
+        lineColors[layer]
+      )
+      .setPaintProperty(
+        'vpromm',
+        'line-color',
+        lineColors[layer]
+      );
   },
 
   componentWillReceiveProps: function ({ layer, lng, lat, zoom, activeRoad }) {

--- a/app/assets/scripts/views/explore.js
+++ b/app/assets/scripts/views/explore.js
@@ -103,7 +103,7 @@ var Explore = React.createClass({
             'line-color': '#D3D3D3'
           },
           layout: { 'line-cap': 'round' },
-          filter: ['==', 'or_vpromms', activeRoad]
+          filter: ['==', 'vpromm_id', activeRoad]
         })
         .addLayer({
           id: 'novpromm',
@@ -121,7 +121,7 @@ var Explore = React.createClass({
             ]
           },
           layout: { 'line-cap': 'round' },
-          filter: ['!has', 'or_vpromms'],
+          filter: ['!has', 'vpromm_id'],
           maxzoom: 11
         })
         .addLayer({
@@ -141,7 +141,7 @@ var Explore = React.createClass({
             'line-dasharray': [1, 2, 1]
           },
           layout: { 'line-cap': 'round' },
-          filter: ['!has', 'or_vpromms'],
+          filter: ['!has', 'vpromm_id'],
           minzoom: 10
         })
         .addLayer({
@@ -162,7 +162,7 @@ var Explore = React.createClass({
           layout: {
             'line-cap': 'round'
           },
-          filter: ['has', 'or_vpromms']
+          filter: ['has', 'vpromm_id']
         })
         .addLayer({
           id: 'vpromm-label',
@@ -175,7 +175,7 @@ var Explore = React.createClass({
           layout: {
             'symbol-placement': 'line',
             'text-anchor': 'top',
-            'text-field': ['get', 'or_vpromms'],
+            'text-field': ['get', 'vpromm_id'],
             'text-font': ['DIN Offc Pro Regular', 'Open Sans Semibold'],
             'text-size': 10
           }
@@ -197,7 +197,7 @@ var Explore = React.createClass({
             'line-opacity': 0
           },
           layout: {'line-cap': 'round'},
-          filter: ['has', 'or_vpromms']
+          filter: ['has', 'vpromm_id']
         })
         .setPaintProperty(
           'novpromm',
@@ -216,19 +216,12 @@ var Explore = React.createClass({
         );
 
       this.map.on('mousemove', (e) => {
-        // console.log('moved on map');
         const features = this.map.queryRenderedFeatures(e.point, {layers: ['vpromm-interaction']});
-        features.forEach(f => {
-          console.log(f);
-          if (f.properties.or_section_delivery_vehicle) {
-            console.log('prop', f.properties.or_section_delivery_vehicle);
-          }
-        });
         this.map.getCanvas().style.cursor = features.length ? 'pointer' : '';
       });
 
       this.map.on('click', 'vpromm-interaction', (e) => {
-        const vpromm = _.get(e, 'features[0].properties.or_vpromms', null);
+        const vpromm = _.get(e, 'features[0].properties.vpromm_id', null);
         if (vpromm) {
           this.props.router.push(`/${language}/assets/road/${vpromm}`);
         }
@@ -262,7 +255,7 @@ var Explore = React.createClass({
       this.map.flyTo({ center: [lng, lat], zoom });
     }
     if (activeRoad !== this.props.activeRoad) {
-      this.map.setFilter('active_road', ['==', 'or_vpromms', activeRoad]);
+      this.map.setFilter('active_road', ['==', 'vpromm_id', activeRoad]);
       this.props.fetchActiveRoad(activeRoad);
     }
   },


### PR DESCRIPTION
@geohacker - once the new tileset has been uploaded, I can give this a proper test, but this update should work for the new tilesets that we generate, combining all properties into a single tileset.